### PR TITLE
Bug fix for XML::Rabbit::Node

### DIFF
--- a/lib/XML/Rabbit/Node.pm
+++ b/lib/XML/Rabbit/Node.pm
@@ -6,6 +6,14 @@ use Moose::Role;
 
 # ABSTRACT: Node base class
 
+# Preload XPath attribute traits
+use XML::Rabbit::Trait::XPathValue;
+use XML::Rabbit::Trait::XPathValueList;
+use XML::Rabbit::Trait::XPathValueMap;
+use XML::Rabbit::Trait::XPathObject;
+use XML::Rabbit::Trait::XPathObjectList;
+use XML::Rabbit::Trait::XPathObjectMap;
+
 =attr node
 
 An instance of a L<XML::LibXML::Node> class representing a node in an XML document tree. Read Only.

--- a/t/regression/node_attribute_traits.t
+++ b/t/regression/node_attribute_traits.t
@@ -1,0 +1,6 @@
+#!perl -T
+
+use strict;
+use warnings;
+use Test::Most tests => 1;
+lives_ok( sub { use lib 't/lib'; require W3C::XHTML::Body } );


### PR DESCRIPTION
I ran into compilation errors when loading XML::Rabbit::Node consumers because the role wasn't preloading the various traits like XML::Rabbit::RootNode does. This patch fixes it and provides a simple regression test against it.
