### PR TITLE
Add Perl::Critic configuration

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -35,6 +35,7 @@ move = README.mkdn
 [PodSyntaxTests]
 [PodCoverageTests]
 [Test::Perl::Critic]
+critic_config = xt/author/perlcritic.rc
 [Test::Kwalitee]
 [NoTabsTests]
 [EOLTests]

--- a/xt/author/perlcritic.rc
+++ b/xt/author/perlcritic.rc
@@ -1,0 +1,2 @@
+verbose = 8
+exclude = ValuesAndExpressions::ProhibitAccessOfPrivateData


### PR DESCRIPTION
Perl::Critic tests were failing against my default (brutal, lots of policies from CPAN) configuration, so I added a bare-bones configuration file that passes. It also reports the policy modules that cause failures.
