### PR TITLE
POD for constructor options

### DIFF
--- a/lib/XML/Rabbit.pm
+++ b/lib/XML/Rabbit.pm
@@ -67,7 +67,19 @@ sub init_meta {
 
 =head1 SYNOPSIS
 
-    my $xhtml = W3C::XHTML->new( file => 'index.xhtml' );
+    my $xhtml = W3C::XHTML->new(
+        file => 'index.xhtml',
+
+        # or string...
+        xml => $xml,
+
+        # or filehandle...
+        fh => $fh,
+
+        # or XML::LibXML::Document object
+        dom => $dom,
+    );
+
     print "Title: " . $xhtml->title . "\n";
     print "First image source: " . $xhtml->body->images->[0]->src . "\n";
 


### PR DESCRIPTION
Hi,

It is confusing that the only place that the constructor arguments are documented in is XML::Rabbit::Role::Document (which is not mentioned in the documentation for XML::Rabbit itself)

thanks,
Michael
